### PR TITLE
Ensure that the e.target has `dataset` object, before accessing its child properties.

### DIFF
--- a/src/modal.jsx
+++ b/src/modal.jsx
@@ -99,7 +99,7 @@ class Modal extends React.Component {
     };
 
     const hide = () => {
-      const kitid = e.target.dataset.kitid;
+      const kitid = (e.target.dataset ? e.target.dataset.kitid : undefined);
 
 
       if (typeof kitid !== 'undefined') {


### PR DESCRIPTION
Otherwise it triggers the following error:
modal.js:151 Uncaught TypeError: Cannot read property 'kitid' of undefined(…)